### PR TITLE
Use a r2d2 sqlite connection pool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
 name = "ssb-db"
-version = "0.1.7"
+version = "0.2.0"
 authors = ["Piet Geursen <pietgeursen@gmail.com>"]
 edition = "2018"
 license = "LGPL-3.0"
 description = "The most basic sqlite backed db that you need to do replication on ssb"
 
-
 [dependencies]
-diesel = { version = "1.4.3", features = ["sqlite"] }
+diesel = { version = "1.4.3", features = ["sqlite", "r2d2"] }
 diesel_migrations = "1.4.0"
 flumedb = "0.1.6"
 itertools = "0.8.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,11 @@ use ssb_multiformats::multikey::Multikey;
 
 pub trait SsbDb {
     /// Append a batch of valid ssb messages authored by the `feed_id`.
-    fn append_batch<T: 'static + AsRef<[u8]>>(&self, feed_id: &Multikey, messages: &[T]) -> Result<()>;
+    fn append_batch<T: 'static + AsRef<[u8]>>(
+        &mut self,
+        feed_id: &Multikey,
+        messages: &[T],
+    ) -> Result<()>;
     /// Get an entry by its ssb message key.
     fn get_entry_by_key(&self, message_key: &Multihash) -> Result<Vec<u8>>;
     /// Get an entry by its sequence key + author.
@@ -79,7 +83,7 @@ pub trait SsbDb {
     ) -> Result<Vec<Vec<u8>>>;
     /// You can rebuild the indexes in sqlite db (but not the offset file) if they become
     /// corrupted.
-    fn rebuild_indexes(&self) -> Result<()>;
+    fn rebuild_indexes(&mut self) -> Result<()>;
 }
 
 #[cfg(test)]
@@ -96,7 +100,7 @@ mod tests {
         let key = Multihash::from_legacy(key_str.as_bytes()).unwrap().0;
 
         let db_path = "/tmp/test_get_entry_by_key.sqlite3";
-        let db = SqliteSsbDb::new(db_path, "./test_vecs/piet.offset");
+        let mut db = SqliteSsbDb::new(db_path, "./test_vecs/piet.offset");
         db.update_indexes_from_offset_file().unwrap();
 
         let res = db.get_entry_by_key(&key);
@@ -116,7 +120,7 @@ mod tests {
         let author = Multikey::from_legacy(author_str.as_bytes()).unwrap().0;
 
         let db_path = "/tmp/test_get_latest_seq.sqlite3";
-        let db = SqliteSsbDb::new(db_path, "./test_vecs/piet.offset");
+        let mut db = SqliteSsbDb::new(db_path, "./test_vecs/piet.offset");
         db.update_indexes_from_offset_file().unwrap();
 
         let res = db.get_feed_latest_sequence(&author);
@@ -131,7 +135,7 @@ mod tests {
         let author = Multikey::from_legacy(author_str.as_bytes()).unwrap().0;
 
         let db_path = "/tmp/test_get_entries_kv.sqlite3";
-        let db = SqliteSsbDb::new(db_path, "./test_vecs/piet.offset");
+        let mut db = SqliteSsbDb::new(db_path, "./test_vecs/piet.offset");
         db.update_indexes_from_offset_file().unwrap();
 
         let res = db
@@ -151,7 +155,7 @@ mod tests {
         let author = Multikey::from_legacy(author_str.as_bytes()).unwrap().0;
 
         let db_path = "/tmp/test_get_entries_kv_limit.sqlite3";
-        let db = SqliteSsbDb::new(db_path, "./test_vecs/piet.offset");
+        let mut db = SqliteSsbDb::new(db_path, "./test_vecs/piet.offset");
         db.update_indexes_from_offset_file().unwrap();
 
         let res = db
@@ -171,7 +175,7 @@ mod tests {
         let author = Multikey::from_legacy(author_str.as_bytes()).unwrap().0;
 
         let db_path = "/tmp/test_get_entries_k.sqlite3";
-        let db = SqliteSsbDb::new(db_path, "./test_vecs/piet.offset");
+        let mut db = SqliteSsbDb::new(db_path, "./test_vecs/piet.offset");
         db.update_indexes_from_offset_file().unwrap();
 
         let res = db
@@ -193,7 +197,7 @@ mod tests {
         let author = Multikey::from_legacy(author_str.as_bytes()).unwrap().0;
 
         let db_path = "/tmp/test_get_entries_v.sqlite3";
-        let db = SqliteSsbDb::new(db_path, "./test_vecs/piet.offset");
+        let mut db = SqliteSsbDb::new(db_path, "./test_vecs/piet.offset");
         db.update_indexes_from_offset_file().unwrap();
 
         let res = db
@@ -214,7 +218,7 @@ mod tests {
         let author = Multikey::from_legacy(author_str.as_bytes()).unwrap().0;
 
         let db_path = "/tmp/test_get_entries_no_kv.sqlite3";
-        let db = SqliteSsbDb::new(db_path, "./test_vecs/piet.offset");
+        let mut db = SqliteSsbDb::new(db_path, "./test_vecs/piet.offset");
         db.update_indexes_from_offset_file().unwrap();
 
         let res = db.get_entries_newer_than_sequence(&author, 6000, None, false, false);
@@ -235,7 +239,7 @@ mod tests {
 
         let db_path = "/tmp/test_append_batch.sqlite3";
         let offset_path = "/tmp/test_append_batch.offset";
-        let db = SqliteSsbDb::new(db_path, offset_path);
+        let mut db = SqliteSsbDb::new(db_path, offset_path);
 
         let res = db.append_batch(&author, &entries.as_slice());
         assert!(res.is_ok());
@@ -255,7 +259,7 @@ mod tests {
         let author = Multikey::from_legacy(author_str.as_bytes()).unwrap().0;
 
         let db_path = "/tmp/test_rebuild_indexes.sqlite3";
-        let db = SqliteSsbDb::new(db_path, "./test_vecs/piet.offset");
+        let mut db = SqliteSsbDb::new(db_path, "./test_vecs/piet.offset");
         db.update_indexes_from_offset_file().unwrap();
 
         let res = db.rebuild_indexes();

--- a/src/sqlite_ssb_db/mod.rs
+++ b/src/sqlite_ssb_db/mod.rs
@@ -2,6 +2,7 @@ use flumedb::offset_log::OffsetLog;
 use flumedb::{FlumeLog, IterAtOffset};
 
 use diesel::prelude::*;
+use diesel::r2d2::{ConnectionManager, Pool};
 use diesel::sqlite::SqliteConnection;
 use diesel_migrations::any_pending_migrations;
 use itertools::Itertools;
@@ -10,7 +11,6 @@ use ssb_legacy_msg_data;
 use ssb_legacy_msg_data::value::Value;
 use ssb_multiformats::multihash::Multihash;
 use ssb_multiformats::multikey::Multikey;
-use std::cell::RefCell;
 
 use crate::db;
 use crate::error::*;
@@ -23,8 +23,8 @@ use db::{
 };
 
 pub struct SqliteSsbDb {
-    connection: RefCell<SqliteConnection>,
-    offset_log: RefCell<OffsetLog<u32>>,
+    pool: Pool<ConnectionManager<SqliteConnection>>,
+    offset_log: OffsetLog<u32>,
     db_path: String,
 }
 
@@ -32,7 +32,7 @@ embed_migrations!();
 
 impl SqliteSsbDb {
     pub fn new<S: AsRef<str>>(database_path: S, offset_log_path: S) -> SqliteSsbDb {
-        let connection = setup_connection(database_path.as_ref());
+        let pool = setup_connection(database_path.as_ref());
 
         let offset_log = match OffsetLog::new(&offset_log_path.as_ref()) {
             Ok(log) => log,
@@ -41,20 +41,20 @@ impl SqliteSsbDb {
             }
         };
         SqliteSsbDb {
-            connection: RefCell::new(connection),
-            offset_log: RefCell::new(offset_log),
+            pool,
+            offset_log,
             db_path: database_path.as_ref().to_owned(),
         }
     }
 
-    pub fn update_indexes_from_offset_file(&self) -> Result<()> {
+    pub fn update_indexes_from_offset_file(&mut self) -> Result<()> {
         //We're using Max of flume_seq.
         //When the db is empty, we'll get None.
         //When there is one item in the db, we'll get 0 (it's the first seq number you get)
         //When there's more than one you'll get some >0 number
 
-        let connection = self.connection.borrow_mut();
-        let offset_log = self.offset_log.borrow();
+        let connection = &self.pool.get().expect("Unable to get connection from pool");
+        let offset_log = &self.offset_log;
 
         let max_seq = get_latest(&connection)
             .context(UnableToGetLatestSequence)?
@@ -91,10 +91,9 @@ impl SqliteSsbDb {
 }
 
 impl SsbDb for SqliteSsbDb {
-    fn append_batch<T: AsRef<[u8]>>(&self, _: &Multikey, messages: &[T]) -> Result<()> {
+    fn append_batch<T: AsRef<[u8]>>(&mut self, _: &Multikey, messages: &[T]) -> Result<()> {
         // First, append the messages to flume
         self.offset_log
-            .borrow_mut()
             .append_batch(messages)
             .map_err(|_| Error::OffsetAppendError {})?;
 
@@ -102,19 +101,18 @@ impl SsbDb for SqliteSsbDb {
     }
     fn get_entry_by_key<'a>(&'a self, message_key: &Multihash) -> Result<Vec<u8>> {
         let flume_seq = find_message_flume_seq_by_key(
-            &self.connection.borrow(),
+            &self.pool.get().expect("Unable to get connection from pool"),
             &message_key.to_legacy_string(),
         )
         .context(MessageNotFound)?;
         self.offset_log
-            .borrow()
             .get(flume_seq)
             .map_err(|_| Error::OffsetGetError {})
     }
 
     fn get_entry_by_seq(&self, feed_id: &Multikey, sequence: i32) -> Result<Option<Vec<u8>>> {
         let flume_seq = find_message_flume_seq_by_author_and_sequence(
-            &self.connection.borrow(),
+            &self.pool.get().expect("Unable to get connection from pool"),
             &feed_id.to_legacy_string(),
             sequence,
         )
@@ -123,15 +121,17 @@ impl SsbDb for SqliteSsbDb {
         flume_seq
             .map(|flume_seq| {
                 self.offset_log
-                    .borrow()
                     .get(flume_seq as u64)
                     .map_err(|_| Error::OffsetGetError {})
             })
             .transpose()
     }
     fn get_feed_latest_sequence(&self, feed_id: &Multikey) -> Result<Option<i32>> {
-        find_feed_latest_seq(&self.connection.borrow(), &feed_id.to_legacy_string())
-            .context(FeedNotFound)
+        find_feed_latest_seq(
+            &self.pool.get().expect("Unable to get connection from pool"),
+            &feed_id.to_legacy_string(),
+        )
+        .context(FeedNotFound)
     }
     fn get_entries_newer_than_sequence<'a>(
         &'a self,
@@ -142,7 +142,7 @@ impl SsbDb for SqliteSsbDb {
         include_values: bool,
     ) -> Result<Vec<Vec<u8>>> {
         let seqs = find_feed_flume_seqs_newer_than(
-            &self.connection.borrow(),
+            &self.pool.get().expect("Unable to get connection from pool"),
             &feed_id.to_legacy_string(),
             sequence,
             limit,
@@ -155,7 +155,6 @@ impl SsbDb for SqliteSsbDb {
                 .iter()
                 .flat_map(|seq| {
                     self.offset_log
-                        .borrow()
                         .get(*seq)
                         .map_err(|_| Error::OffsetGetError {})
                 })
@@ -166,7 +165,6 @@ impl SsbDb for SqliteSsbDb {
                 seqs.iter()
                     .flat_map(|seq| {
                         self.offset_log
-                            .borrow()
                             .get(*seq)
                             .map_err(|_| Error::OffsetGetError {})
                     })
@@ -193,23 +191,24 @@ impl SsbDb for SqliteSsbDb {
                 .iter()
                 .map(|seq| {
                     self.offset_log
-                        .borrow()
                         .get(*seq)
                         .map_err(|_| Error::OffsetGetError {})
                 })
                 .collect(),
         }
     }
-    fn rebuild_indexes(&self) -> Result<()> {
+    fn rebuild_indexes(&mut self) -> Result<()> {
         std::fs::remove_file(&self.db_path).unwrap();
-        self.connection.replace(setup_connection(&self.db_path));
+        self.pool = setup_connection(&self.db_path);
         self.update_indexes_from_offset_file()
     }
 }
-fn setup_connection(database_path: &str) -> SqliteConnection {
+fn setup_connection(database_path: &str) -> Pool<ConnectionManager<SqliteConnection>> {
     let database_url = to_sqlite_uri(database_path, "rwc");
-    let connection = SqliteConnection::establish(&database_url)
-        .expect(&format!("Error connecting to {}", database_url));
+    let connection_manager = ConnectionManager::new(database_url);
+    let pool = Pool::new(connection_manager).unwrap();
+
+    let connection = pool.get().unwrap();
 
     if let Err(_) = any_pending_migrations(&connection) {
         embedded_migrations::run(&connection).unwrap();
@@ -220,7 +219,7 @@ fn setup_connection(database_path: &str) -> SqliteConnection {
         embedded_migrations::run(&connection).unwrap();
     }
 
-    connection
+    pool
 }
 fn to_sqlite_uri(path: &str, rw_mode: &str) -> String {
     format!("file:{}?mode={}", path, rw_mode)


### PR DESCRIPTION
There was some reason I used interior mutability when I wrote this but I don't love that decision.

- I'm not keen on it blowing at runtime (when there's an existing mutable borrow) if the caller makes a mistake.
- It means the `SqliteSsbDb` type isn't `Sync` which means I can't put it behind a `RwLock` to improve performance when usage is read heavy.

